### PR TITLE
Config DNS Resource: Acceptance Tests 

### DIFF
--- a/builtin/providers/akamai/provider_test.go
+++ b/builtin/providers/akamai/provider_test.go
@@ -1,12 +1,28 @@
 package akamai
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"akamai": testAccProvider,
+	}
+}
 
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func testAccPreCheck(t *testing.T) {
+
 }

--- a/builtin/providers/akamai/resource_fastdns_zone.go
+++ b/builtin/providers/akamai/resource_fastdns_zone.go
@@ -1,10 +1,12 @@
 package akamai
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v1"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -24,7 +26,7 @@ func resourceFastDNSZone() *schema.Resource {
 				Required: true,
 			},
 			"a": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -48,7 +50,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"aaaa": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -72,7 +74,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"afsdb": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -100,7 +102,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"cname": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -124,7 +126,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"dnskey": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -160,7 +162,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"ds": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -196,7 +198,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"hinfo": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -224,7 +226,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"loc": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -248,7 +250,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"mx": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -276,7 +278,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"naptr": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -320,7 +322,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"ns": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -344,7 +346,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"nsec3": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -388,7 +390,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"nsec3param": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -424,7 +426,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"ptr": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -448,7 +450,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"rp": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -476,7 +478,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"rrsig": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -532,8 +534,23 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"soa": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf(
+						"%s-%s-%s-%s-%s-%s-%s",
+						m["ttl"],
+						m["originserver"],
+						m["contact"],
+						m["refresh"],
+						m["retry"],
+						m["expire"],
+						m["minimum"],
+					))
+					return hashcode.String(buf.String())
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ttl": {
@@ -572,7 +589,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"spf": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -596,7 +613,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"srv": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -632,7 +649,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"sshfp": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -664,7 +681,7 @@ func resourceFastDNSZone() *schema.Resource {
 				},
 			},
 			"txt": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -748,7 +765,7 @@ func assignFields(record dns.DNSRecord, d map[string]interface{}) {
 func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 	a, ok := d.GetOk("a")
 	if ok {
-		for _, val := range a.([]interface{}) {
+		for _, val := range a.(*schema.Set).List() {
 			record := dns.NewARecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -757,7 +774,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	aaaa, ok := d.GetOk("aaaa")
 	if ok {
-		for _, val := range aaaa.([]interface{}) {
+		for _, val := range aaaa.(*schema.Set).List() {
 			record := dns.NewAaaaRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -766,7 +783,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	afsdb, ok := d.GetOk("afsdb")
 	if ok {
-		for _, val := range afsdb.([]interface{}) {
+		for _, val := range afsdb.(*schema.Set).List() {
 			record := dns.NewAfsdbRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -775,7 +792,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	cname, ok := d.GetOk("cname")
 	if ok {
-		for _, val := range cname.([]interface{}) {
+		for _, val := range cname.(*schema.Set).List() {
 			record := dns.NewCnameRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -784,7 +801,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	dnskey, ok := d.GetOk("dnskey")
 	if ok {
-		for _, val := range dnskey.([]interface{}) {
+		for _, val := range dnskey.(*schema.Set).List() {
 			record := dns.NewDnskeyRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -793,7 +810,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	ds, ok := d.GetOk("ds")
 	if ok {
-		for _, val := range ds.([]interface{}) {
+		for _, val := range ds.(*schema.Set).List() {
 			record := dns.NewDsRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -802,7 +819,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	hinfo, ok := d.GetOk("hinfo")
 	if ok {
-		for _, val := range hinfo.([]interface{}) {
+		for _, val := range hinfo.(*schema.Set).List() {
 			record := dns.NewHinfoRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -811,7 +828,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	loc, ok := d.GetOk("loc")
 	if ok {
-		for _, val := range loc.([]interface{}) {
+		for _, val := range loc.(*schema.Set).List() {
 			record := dns.NewLocRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -820,7 +837,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	mx, ok := d.GetOk("mx")
 	if ok {
-		for _, val := range mx.([]interface{}) {
+		for _, val := range mx.(*schema.Set).List() {
 			record := dns.NewMxRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -829,7 +846,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	naptr, ok := d.GetOk("naptr")
 	if ok {
-		for _, val := range naptr.([]interface{}) {
+		for _, val := range naptr.(*schema.Set).List() {
 			record := dns.NewNaptrRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -838,7 +855,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	ns, ok := d.GetOk("ns")
 	if ok {
-		for _, val := range ns.([]interface{}) {
+		for _, val := range ns.(*schema.Set).List() {
 			record := dns.NewNsRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -847,7 +864,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	nsec3, ok := d.GetOk("nsec3")
 	if ok {
-		for _, val := range nsec3.([]interface{}) {
+		for _, val := range nsec3.(*schema.Set).List() {
 			record := dns.NewNsec3Record()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -856,7 +873,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	nsec3param, ok := d.GetOk("nsec3param")
 	if ok {
-		for _, val := range nsec3param.([]interface{}) {
+		for _, val := range nsec3param.(*schema.Set).List() {
 			record := dns.NewNsec3paramRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -865,7 +882,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	ptr, ok := d.GetOk("ptr")
 	if ok {
-		for _, val := range ptr.([]interface{}) {
+		for _, val := range ptr.(*schema.Set).List() {
 			record := dns.NewPtrRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -874,7 +891,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	rp, ok := d.GetOk("rp")
 	if ok {
-		for _, val := range rp.([]interface{}) {
+		for _, val := range rp.(*schema.Set).List() {
 			record := dns.NewRpRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -883,7 +900,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	rrsig, ok := d.GetOk("rrsig")
 	if ok {
-		for _, val := range rrsig.([]interface{}) {
+		for _, val := range rrsig.(*schema.Set).List() {
 			record := dns.NewRrsigRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -892,7 +909,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	soa, ok := d.GetOk("soa")
 	if ok {
-		for _, val := range soa.([]interface{}) {
+		for _, val := range soa.(*schema.Set).List() {
 			record := dns.NewSoaRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -901,7 +918,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	spf, ok := d.GetOk("spf")
 	if ok {
-		for _, val := range spf.([]interface{}) {
+		for _, val := range spf.(*schema.Set).List() {
 			record := dns.NewSpfRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -910,7 +927,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	srv, ok := d.GetOk("srv")
 	if ok {
-		for _, val := range srv.([]interface{}) {
+		for _, val := range srv.(*schema.Set).List() {
 			record := dns.NewSrvRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -919,7 +936,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	sshfp, ok := d.GetOk("sshfp")
 	if ok {
-		for _, val := range sshfp.([]interface{}) {
+		for _, val := range sshfp.(*schema.Set).List() {
 			record := dns.NewSshfpRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -928,7 +945,7 @@ func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 
 	txt, ok := d.GetOk("txt")
 	if ok {
-		for _, val := range txt.([]interface{}) {
+		for _, val := range txt.(*schema.Set).List() {
 			record := dns.NewTxtRecord()
 			assignFields(record, val.(map[string]interface{}))
 			zone.AddRecord(record)
@@ -1073,7 +1090,9 @@ func marshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 	}
 	d.Set("rrsig", rrsig)
 
-	d.Set("soa", zone.Zone.Soa.ToMap())
+	soa := make([]map[string]interface{}, 1)
+	soa[0] = zone.Zone.Soa.ToMap()
+	d.Set("soa", soa)
 
 	spf := make([]map[string]interface{}, len(zone.Zone.Spf))
 	for i, v := range zone.Zone.Spf {

--- a/builtin/providers/akamai/resource_fastdns_zone.go
+++ b/builtin/providers/akamai/resource_fastdns_zone.go
@@ -770,214 +770,387 @@ func assignFields(record dns.DNSRecord, d map[string]interface{}) {
 	}
 }
 
-// Unmarshal the config data from the terraform config file to our local types
+// Sometimes records exist in the API but not in tf config
+// In that case we will merge our records from the config with the API records
+// But those API records don't ever get saved in the tf config
+// This is on purpose because the Akamai API will inject several
+// Default records to a given zone and we don't want those to show up
+// In diffs or in acceptance tests
+func mergeConfigs(recordType string, records []interface{}, s *schema.Resource, d *schema.ResourceData) *schema.Set {
+	recordsInStateFile, recordsInConfigFile := d.GetChange(recordType)
+	recordsInAPI := schema.NewSet(
+		schema.HashResource(s.Schema[recordType].Elem.(*schema.Resource)),
+		records,
+	)
+	recordsInAPIButNotInStateFile := recordsInAPI.Difference(recordsInStateFile.(*schema.Set))
+	mergedRecordsToBeSaved := recordsInConfigFile.(*schema.Set).Union(recordsInAPIButNotInStateFile)
+
+	return mergedRecordsToBeSaved
+}
+
+// Unmarshal the config data from the terraform config file to our local types so it can be saved
 func unmarshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
-	a, ok := d.GetOk("a")
+	s := resourceFastDNSZone()
+
+	_, ok := d.GetOk("a")
 	if ok {
-		for _, val := range a.(*schema.Set).List() {
-			record := dns.NewARecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("a") {
+			zoneARecords := make([]interface{}, len(zone.Zone.A))
+			for k, v := range zone.Zone.A {
+				zoneARecords[k] = v.ToMap()
+			}
+			mergedARecords := mergeConfigs("a", zoneARecords, s, d)
+			zone.Zone.A = nil
+			for _, val := range mergedARecords.List() {
+				record := dns.NewARecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	aaaa, ok := d.GetOk("aaaa")
+	_, ok = d.GetOk("aaaa")
 	if ok {
-		for _, val := range aaaa.(*schema.Set).List() {
-			record := dns.NewAaaaRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("aaaa") {
+			zoneAaaaRecords := make([]interface{}, len(zone.Zone.Aaaa))
+			for k, v := range zone.Zone.Aaaa {
+				zoneAaaaRecords[k] = v.ToMap()
+			}
+			mergedAaaaRecords := mergeConfigs("aaaa", zoneAaaaRecords, s, d)
+			zone.Zone.Aaaa = nil
+			for _, val := range mergedAaaaRecords.List() {
+				record := dns.NewAaaaRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	afsdb, ok := d.GetOk("afsdb")
+	_, ok = d.GetOk("afsdb")
 	if ok {
-		for _, val := range afsdb.(*schema.Set).List() {
-			record := dns.NewAfsdbRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("afsdb") {
+			zoneAfsdbRecords := make([]interface{}, len(zone.Zone.Afsdb))
+			for k, v := range zone.Zone.Afsdb {
+				zoneAfsdbRecords[k] = v.ToMap()
+			}
+			mergedAfsdbRecords := mergeConfigs("afsdb", zoneAfsdbRecords, s, d)
+			zone.Zone.Afsdb = nil
+			for _, val := range mergedAfsdbRecords.List() {
+				record := dns.NewAfsdbRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	cname, ok := d.GetOk("cname")
+	_, ok = d.GetOk("cname")
 	if ok {
-		for _, val := range cname.(*schema.Set).List() {
-			record := dns.NewCnameRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("cname") {
+			zoneCnameRecords := make([]interface{}, len(zone.Zone.Cname))
+			for k, v := range zone.Zone.Cname {
+				zoneCnameRecords[k] = v.ToMap()
+			}
+			mergedCnameRecords := mergeConfigs("cname", zoneCnameRecords, s, d)
+			zone.Zone.Cname = nil
+			for _, val := range mergedCnameRecords.List() {
+				record := dns.NewCnameRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	dnskey, ok := d.GetOk("dnskey")
+	_, ok = d.GetOk("dnskey")
 	if ok {
-		for _, val := range dnskey.(*schema.Set).List() {
-			record := dns.NewDnskeyRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("dnskey") {
+			zoneDnskeyRecords := make([]interface{}, len(zone.Zone.Dnskey))
+			for k, v := range zone.Zone.Dnskey {
+				zoneDnskeyRecords[k] = v.ToMap()
+			}
+			mergedDnskeyRecords := mergeConfigs("dnskey", zoneDnskeyRecords, s, d)
+			zone.Zone.Dnskey = nil
+			for _, val := range mergedDnskeyRecords.List() {
+				record := dns.NewDnskeyRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	ds, ok := d.GetOk("ds")
+	_, ok = d.GetOk("ds")
 	if ok {
-		for _, val := range ds.(*schema.Set).List() {
-			record := dns.NewDsRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("ds") {
+			zoneDsRecords := make([]interface{}, len(zone.Zone.Ds))
+			for k, v := range zone.Zone.Ds {
+				zoneDsRecords[k] = v.ToMap()
+			}
+			mergedDsRecords := mergeConfigs("ds", zoneDsRecords, s, d)
+			zone.Zone.Ds = nil
+			for _, val := range mergedDsRecords.List() {
+				record := dns.NewDsRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	hinfo, ok := d.GetOk("hinfo")
+	_, ok = d.GetOk("hinfo")
 	if ok {
-		for _, val := range hinfo.(*schema.Set).List() {
-			record := dns.NewHinfoRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("hinfo") {
+			zoneHinfoRecords := make([]interface{}, len(zone.Zone.Hinfo))
+			for k, v := range zone.Zone.Hinfo {
+				zoneHinfoRecords[k] = v.ToMap()
+			}
+			mergedHinfoRecords := mergeConfigs("hinfo", zoneHinfoRecords, s, d)
+			zone.Zone.Hinfo = nil
+			for _, val := range mergedHinfoRecords.List() {
+				record := dns.NewHinfoRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	loc, ok := d.GetOk("loc")
+	_, ok = d.GetOk("loc")
 	if ok {
-		for _, val := range loc.(*schema.Set).List() {
-			record := dns.NewLocRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("loc") {
+			zoneLocRecords := make([]interface{}, len(zone.Zone.Loc))
+			for k, v := range zone.Zone.Loc {
+				zoneLocRecords[k] = v.ToMap()
+			}
+			mergedLocRecords := mergeConfigs("loc", zoneLocRecords, s, d)
+			zone.Zone.Loc = nil
+			for _, val := range mergedLocRecords.List() {
+				record := dns.NewLocRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	mx, ok := d.GetOk("mx")
+	_, ok = d.GetOk("mx")
 	if ok {
-		for _, val := range mx.(*schema.Set).List() {
-			record := dns.NewMxRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("mx") {
+			zoneMxRecords := make([]interface{}, len(zone.Zone.Mx))
+			for k, v := range zone.Zone.Mx {
+				zoneMxRecords[k] = v.ToMap()
+			}
+			mergedMxRecords := mergeConfigs("mx", zoneMxRecords, s, d)
+			zone.Zone.Mx = nil
+			for _, val := range mergedMxRecords.List() {
+				record := dns.NewMxRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	naptr, ok := d.GetOk("naptr")
+	_, ok = d.GetOk("naptr")
 	if ok {
-		for _, val := range naptr.(*schema.Set).List() {
-			record := dns.NewNaptrRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("naptr") {
+			zoneNaptrRecords := make([]interface{}, len(zone.Zone.Naptr))
+			for k, v := range zone.Zone.Naptr {
+				zoneNaptrRecords[k] = v.ToMap()
+			}
+			mergedNaptrRecords := mergeConfigs("naptr", zoneNaptrRecords, s, d)
+			zone.Zone.Naptr = nil
+			for _, val := range mergedNaptrRecords.List() {
+				record := dns.NewNaptrRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	ns, ok := d.GetOk("ns")
+	_, ok = d.GetOk("ns")
 	if ok {
-		for _, val := range ns.(*schema.Set).List() {
-			record := dns.NewNsRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("ns") {
+			zoneNsRecords := make([]interface{}, len(zone.Zone.Ns))
+			for k, v := range zone.Zone.Ns {
+				zoneNsRecords[k] = v.ToMap()
+			}
+			mergedNsRecords := mergeConfigs("ns", zoneNsRecords, s, d)
+			zone.Zone.Ns = nil
+			for _, val := range mergedNsRecords.List() {
+				record := dns.NewNsRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	nsec3, ok := d.GetOk("nsec3")
+	_, ok = d.GetOk("nsec3")
 	if ok {
-		for _, val := range nsec3.(*schema.Set).List() {
-			record := dns.NewNsec3Record()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("nsec3") {
+			zoneNsec3Records := make([]interface{}, len(zone.Zone.Nsec3))
+			for k, v := range zone.Zone.Nsec3 {
+				zoneNsec3Records[k] = v.ToMap()
+			}
+			mergedNsec3Records := mergeConfigs("nsec3", zoneNsec3Records, s, d)
+			zone.Zone.Nsec3 = nil
+			for _, val := range mergedNsec3Records.List() {
+				record := dns.NewNsec3Record()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	nsec3param, ok := d.GetOk("nsec3param")
+	_, ok = d.GetOk("nsec3param")
 	if ok {
-		for _, val := range nsec3param.(*schema.Set).List() {
-			record := dns.NewNsec3paramRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("nsec3param") {
+			zoneNsec3paramRecords := make([]interface{}, len(zone.Zone.Nsec3param))
+			for k, v := range zone.Zone.Nsec3param {
+				zoneNsec3paramRecords[k] = v.ToMap()
+			}
+			mergedNsec3paramRecords := mergeConfigs("nsec3param", zoneNsec3paramRecords, s, d)
+			zone.Zone.Nsec3param = nil
+			for _, val := range mergedNsec3paramRecords.List() {
+				record := dns.NewNsec3paramRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	ptr, ok := d.GetOk("ptr")
+	_, ok = d.GetOk("ptr")
 	if ok {
-		for _, val := range ptr.(*schema.Set).List() {
-			record := dns.NewPtrRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("ptr") {
+			zonePtrRecords := make([]interface{}, len(zone.Zone.Ptr))
+			for k, v := range zone.Zone.Ptr {
+				zonePtrRecords[k] = v.ToMap()
+			}
+			mergedPtrRecords := mergeConfigs("Ptr", zonePtrRecords, s, d)
+			zone.Zone.Ptr = nil
+			for _, val := range mergedPtrRecords.List() {
+				record := dns.NewPtrRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	rp, ok := d.GetOk("rp")
+	_, ok = d.GetOk("rp")
 	if ok {
-		for _, val := range rp.(*schema.Set).List() {
-			record := dns.NewRpRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("rp") {
+			zoneRpRecords := make([]interface{}, len(zone.Zone.Rp))
+			for k, v := range zone.Zone.Rp {
+				zoneRpRecords[k] = v.ToMap()
+			}
+			mergedRpRecords := mergeConfigs("rp", zoneRpRecords, s, d)
+			zone.Zone.Rp = nil
+			for _, val := range mergedRpRecords.List() {
+				record := dns.NewRpRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	rrsig, ok := d.GetOk("rrsig")
+	_, ok = d.GetOk("rrsig")
 	if ok {
-		for _, val := range rrsig.(*schema.Set).List() {
-			record := dns.NewRrsigRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("rrsig") {
+			zoneRrsigRecords := make([]interface{}, len(zone.Zone.Rrsig))
+			for k, v := range zone.Zone.Rrsig {
+				zoneRrsigRecords[k] = v.ToMap()
+			}
+			mergedRrsigRecords := mergeConfigs("Rrsig", zoneRrsigRecords, s, d)
+			zone.Zone.Rrsig = nil
+			for _, val := range mergedRrsigRecords.List() {
+				record := dns.NewRrsigRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	soa, ok := d.GetOk("soa")
+	_, ok = d.GetOk("soa")
 	if ok {
-		for _, val := range soa.(*schema.Set).List() {
-			record := dns.NewSoaRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("soa") {
+			zoneSoaRecords := make([]interface{}, 1)
+			zoneSoaRecords[0] = zone.Zone.Soa.ToMap()
+			mergedSoaRecords := mergeConfigs("soa", zoneSoaRecords, s, d)
+			zone.Zone.Soa = nil
+			for _, val := range mergedSoaRecords.List() {
+				record := dns.NewSoaRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	spf, ok := d.GetOk("spf")
+	_, ok = d.GetOk("spf")
 	if ok {
-		for _, val := range spf.(*schema.Set).List() {
-			record := dns.NewSpfRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("spf") {
+			zoneSpfRecords := make([]interface{}, len(zone.Zone.Spf))
+			for k, v := range zone.Zone.Spf {
+				zoneSpfRecords[k] = v.ToMap()
+			}
+			mergedSpfRecords := mergeConfigs("spf", zoneSpfRecords, s, d)
+			zone.Zone.Spf = nil
+			for _, val := range mergedSpfRecords.List() {
+				record := dns.NewSpfRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	srv, ok := d.GetOk("srv")
+	_, ok = d.GetOk("srv")
 	if ok {
-		for _, val := range srv.(*schema.Set).List() {
-			record := dns.NewSrvRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("srv") {
+			zoneSrvRecords := make([]interface{}, len(zone.Zone.Srv))
+			for k, v := range zone.Zone.Srv {
+				zoneSrvRecords[k] = v.ToMap()
+			}
+			mergedSrvRecords := mergeConfigs("srv", zoneSrvRecords, s, d)
+			zone.Zone.Srv = nil
+			for _, val := range mergedSrvRecords.List() {
+				record := dns.NewSrvRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	sshfp, ok := d.GetOk("sshfp")
+	_, ok = d.GetOk("sshfp")
 	if ok {
-		for _, val := range sshfp.(*schema.Set).List() {
-			record := dns.NewSshfpRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("sshfp") {
+			zoneSshfpRecords := make([]interface{}, len(zone.Zone.Sshfp))
+			for k, v := range zone.Zone.Sshfp {
+				zoneSshfpRecords[k] = v.ToMap()
+			}
+			mergedSshfpRecords := mergeConfigs("sshfp", zoneSshfpRecords, s, d)
+			zone.Zone.Sshfp = nil
+			for _, val := range mergedSshfpRecords.List() {
+				record := dns.NewSshfpRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 
-	txt, ok := d.GetOk("txt")
+	_, ok = d.GetOk("txt")
 	if ok {
-		for _, val := range txt.(*schema.Set).List() {
-			record := dns.NewTxtRecord()
-			assignFields(record, val.(map[string]interface{}))
-			zone.AddRecord(record)
+		if d.HasChange("txt") {
+			zoneTxtRecords := make([]interface{}, len(zone.Zone.Txt))
+			for k, v := range zone.Zone.Txt {
+				zoneTxtRecords[k] = v.ToMap()
+			}
+			mergedTxtRecords := mergeConfigs("txt", zoneTxtRecords, s, d)
+			zone.Zone.Txt = nil
+			for _, val := range mergedTxtRecords.List() {
+				record := dns.NewTxtRecord()
+				assignFields(record, val.(map[string]interface{}))
+				zone.AddRecord(record)
+			}
 		}
 	}
 }
 
+// Only ever save data from the tf config in the tf state file, to help with
+// api issues. See func unmarshalResourceData for more info.
 func resourceFastDNSZoneRead(d *schema.ResourceData, meta interface{}) error {
-	hostname := d.Get("hostname").(string)
-
-	// find the zone first
-	log.Printf("[INFO] [Akamai FastDNS] Searching for zone [%s]", hostname)
-	zone, err := dns.GetZone(hostname)
-	if err != nil {
-		return err
-	}
-
-	// assign each of the record sets to the resource data
-	marshalResourceData(d, zone)
-
-	// Give terraform the ID
-	d.SetId(fmt.Sprintf("%s-%s-%s", zone.Token, zone.Zone.Name, hostname))
-
 	return nil
 }
 

--- a/builtin/providers/akamai/resource_fastdns_zone.go
+++ b/builtin/providers/akamai/resource_fastdns_zone.go
@@ -1302,6 +1302,9 @@ func marshalResourceData(d *schema.ResourceData, zone *dns.Zone) {
 }
 
 func resourceFastDNSZoneDelete(d *schema.ResourceData, meta interface{}) error {
+	dnsWriteLock.Lock()
+	defer dnsWriteLock.Unlock()
+
 	hostname := d.Get("hostname").(string)
 
 	// find the zone first

--- a/builtin/providers/akamai/resource_fastdns_zone_test.go
+++ b/builtin/providers/akamai/resource_fastdns_zone_test.go
@@ -1,0 +1,71 @@
+package akamai
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccAkamaiFastDNSZoneConfig = fmt.Sprintf(`
+provider "akamai" {
+  edgerc = "/Users/Johanna/.edgerc"
+  fastdns_section = "dns"
+}
+
+resource "akamai_fastdns_zone" "tf_acc_test_zone" {
+  hostname = "akamaideveloper.net"
+  soa {
+    ttl = 900
+    originserver = "akamaideveloper.net."
+    contact = "hostmaster.akamaideveloper.net."
+    refresh = 900
+    retry = 300
+    expire = 604800
+    minimum = 180
+  }
+  a {
+    name = "web"
+    ttl = 900
+    active = true
+    target = "1.2.3.4"
+  }
+  a {
+    name = "web"
+    ttl = 600
+    active = true
+    target = "5.6.7.8"
+  }
+  cname {
+    name = "wwwq"
+    ttl = 600
+    active = true
+    target = "blog.akamaideveloper.net."
+  }
+}
+`)
+
+func TestAccAkamaiFastDNSZone_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiFastDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAkamaiFastDNSZoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiFastDNSZoneExists,
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAkamaiFastDNSZoneDestroy(s *terraform.State) error {
+	return nil
+}
+
+func testAccCheckAkamaiFastDNSZoneExists(s *terraform.State) error {
+	return nil
+}

--- a/builtin/providers/akamai/resource_fastdns_zone_test.go
+++ b/builtin/providers/akamai/resource_fastdns_zone_test.go
@@ -49,6 +49,25 @@ resource "akamai_fastdns_zone" "tf_acc_test_zone" {
 }
 `)
 
+var testAccAkamaiFastDNSZoneConfigWithCounter = fmt.Sprintf(`
+provider "akamai" {
+  edgerc = "/Users/Johanna/.edgerc"
+  fastdns_section = "dns"
+}
+
+resource "akamai_fastdns_zone" "tf_acc_test_zone_counter" {
+  count = "3"
+  hostname = "akamaideveloper.net"
+
+  a {
+    name = "www${count.index}"
+    ttl = 900
+    active = true
+    target = "1.2.3.4"
+  }
+}
+`)
+
 func TestAccAkamaiFastDNSZone_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,6 +76,22 @@ func TestAccAkamaiFastDNSZone_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAkamaiFastDNSZoneConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiFastDNSZoneExists,
+				),
+			},
+		},
+	})
+}
+
+func TestAccAkamaiFastDNSZone_counter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAkamaiFastDNSZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAkamaiFastDNSZoneConfigWithCounter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAkamaiFastDNSZoneExists,
 				),

--- a/builtin/providers/akamai/resource_fastdns_zone_test.go
+++ b/builtin/providers/akamai/resource_fastdns_zone_test.go
@@ -2,10 +2,13 @@ package akamai
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v1"
 )
 
 var testAccAkamaiFastDNSZoneConfig = fmt.Sprintf(`
@@ -63,9 +66,55 @@ func TestAccAkamaiFastDNSZone_basic(t *testing.T) {
 }
 
 func testAccCheckAkamaiFastDNSZoneDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_fastdns_zone" {
+			continue
+		}
+
+		hostname := strings.Split(rs.Primary.ID, "-")[2]
+		zone, err := dns.GetZone(hostname)
+		if err != nil {
+			return err
+		}
+		if len(zone.Zone.A) > 0 ||
+			len(zone.Zone.Aaaa) > 0 ||
+			len(zone.Zone.Afsdb) > 0 ||
+			len(zone.Zone.Cname) > 0 ||
+			len(zone.Zone.Dnskey) > 0 ||
+			len(zone.Zone.Ds) > 0 ||
+			len(zone.Zone.Hinfo) > 0 ||
+			len(zone.Zone.Loc) > 0 ||
+			len(zone.Zone.Mx) > 0 ||
+			len(zone.Zone.Naptr) > 0 ||
+			len(zone.Zone.Nsec3) > 0 ||
+			len(zone.Zone.Nsec3param) > 0 ||
+			len(zone.Zone.Ptr) > 0 ||
+			len(zone.Zone.Rp) > 0 ||
+			len(zone.Zone.Rrsig) > 0 ||
+			len(zone.Zone.Spf) > 0 ||
+			len(zone.Zone.Srv) > 0 ||
+			len(zone.Zone.Sshfp) > 0 ||
+			len(zone.Zone.Txt) > 0 {
+			// These never get deleted
+			// len(zone.Zone.Ns) > 0 ||
+			// len(zone.Zone.Soa) > 0 ||
+			return fmt.Errorf("Zone was not deleted %s", zone)
+		}
+	}
 	return nil
 }
 
 func testAccCheckAkamaiFastDNSZoneExists(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_fastdns_zone" {
+			continue
+		}
+
+		hostname := strings.Split(rs.Primary.ID, "-")[2]
+		_, err := dns.GetZone(hostname)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/builtin/providers/akamai/resource_property_read.go
+++ b/builtin/providers/akamai/resource_property_read.go
@@ -28,7 +28,7 @@ func resourcePropertyRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		
+
 		if len(results.Versions.Items) > 0 {
 			propertyId = results.Versions.Items[0].PropertyID
 		}


### PR DESCRIPTION
This adds acceptance tests for the Config DNS Resource. In the course of writing the tests, some changes to the functionality needed to be changed: 

 - changed all records to `TypeSet` from `TypeList` so they will maintain their order between changes
 - added a mutex for all write operations to prevent overwriting or data loss
 - add a custom set function for the SOA record schema so it ignores the serial value which is calculated locally
 - added a merge function which merges the local config on top of the existing records in the API, since there are several records which get added server side, so these won't conflict with config here
- removed any code which saves data from the API to the state file, only records from the config file go into the state file now